### PR TITLE
Now able to receive commands from MQTT and publish to Energenie devices

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Program Files\\Python37\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.pythonPath": "C:\\Program Files\\Python37\\python.exe"
+    "python.pythonPath": "C:\\Program Files (x86)\\Python37-32\\python.exe"
 }

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -4,7 +4,7 @@
 import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
-from pyenergenie.src.energenie import energenie as energenie
+import pyenergenie.src.energenie as energenie
 from pyenergenie.src.energenie import Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -21,6 +21,7 @@ mqtt_keepalive = 10
 mqtt_username = ""
 mqtt_password = ""
 mqtt_client_id = "agn-sensor01-lon_energenie"
+mqtt_subscribe_client_id = "agn-sensor01-lon_pyenergenie_subscribe"
 mqtt_clean_session = True
 mqtt_publish_topic = "emon"
 mqtt_subscribe_topic = "energenie"
@@ -44,7 +45,7 @@ rx_mqtt_client_connected = False
 def rx_mqtt_on_connect(client, userdata, flags, rc):
 	global mqtt_subscribe_topic
 	global rx_mqtt_client_connected
-	
+
 	print("rx_mqtt: Connected to %s:%s with result code %s" % (client._host, client._port, rc))
 	rx_mqtt_client_connected = True
 	print("rx_mqtt: Set rx_mqtt_client_connected as True = " + str(rx_mqtt_client_connected))
@@ -77,7 +78,7 @@ def rx_mqtt():
 	global mqtt_keepalive
 	global mqtt_username
 	global mqtt_password
-	global mqtt_client_id
+	global mqtt_subscribe_client_id
 	global mqtt_clean_session
 	global mqtt_subscribe_topic
 	global q_rx_mqtt
@@ -86,7 +87,7 @@ def rx_mqtt():
 	print("rx_mqtt: Starting mqtt subscribing loop...")
 	while True:
 		try:
-			fromMqtt = mqtt.Client(client_id=mqtt_client_id, clean_session=mqtt_clean_session)
+			fromMqtt = mqtt.Client(client_id=mqtt_subscribe_client_id, clean_session=mqtt_clean_session)
 			fromMqtt.on_connect = rx_mqtt_on_connect
 			fromMqtt.on_disconnect = rx_mqtt_on_disconnect
 			fromMqtt.on_subscribe = rx_mqtt_on_subscribe

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -124,16 +124,16 @@ def mqtt_tx_energenie():
 			device = energenie.registry.get(name)
 			if str(msg.payload) == "1":
 				print("mqtt_tx_energenie: " + name + " - on")
-				for x in range(0, 5):
-					device.turn_on()
-					print("mqtt_tx_energenie: " + name + " - on attempt " + str(x))
-					time.sleep(0.1)
+				#for x in range(0, 5):
+				device.turn_on()
+				#	print("mqtt_tx_energenie: " + name + " - on attempt " + str(x))
+				#	time.sleep(0.1)
 			else:
 				print("mqtt_tx_energenie: " + name + " - off")
-				for x in range(0, 5):
-					device.turn_off()
-					print("mqtt_tx_energenie: " + name + " - off attempt " + str(x))
-					time.sleep(0.1)
+				#for x in range(0, 5):
+				device.turn_off()
+				#	print("mqtt_tx_energenie: " + name + " - off attempt " + str(x))
+				#	time.sleep(0.1)
 		except Exception as e:
 			print("mqtt_tx_energenie: Exception occurred")
 			print(e)

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -371,6 +371,7 @@ def main():
 	# Main processing loop for the energenie radio; loop command checks receive threads
 	while not programkiller.kill_now:
 		energenie.loop()
+		time.sleep(0.25)
 		# try:
 		# 	msg = q_rx_mqtt.get(block=False,timeout=1)
 		# except Queue.Empty as e:

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -358,20 +358,23 @@ def main():
 			try:
 				print("mqtt_tx_energenie: " + msg.topic + " " + str(msg.payload))
 
-				name = msg.topic.split("/", 2)[1]
+				topic_parts = msg.topic.split("/", 3)
+				name = topic_parts[1]
+				action = topic_parts[2]
 				device = energenie.registry.get(name)
-				if str(msg.payload) == "1":
-					print("mqtt_tx_energenie: " + name + " - on")
-					#for x in range(0, 5):
-					device.turn_on()
-					#	print("mqtt_tx_energenie: " + name + " - on attempt " + str(x))
-					#	time.sleep(0.1)
+				
+				if action == "switch":
+					if str(msg.payload) == "1":
+						print("mqtt_tx_energenie: " + name + " - on")
+						device.turn_on()
+					else:
+						print("mqtt_tx_energenie: " + name + " - off")
+						device.turn_off()
+				elif action == "":
+
 				else:
-					print("mqtt_tx_energenie: " + name + " - off")
-					#for x in range(0, 5):
-					device.turn_off()
-					#	print("mqtt_tx_energenie: " + name + " - off attempt " + str(x))
-					#	time.sleep(0.1)
+					# Action not found
+					print("mqtt_tx_energenie: action '" + action + "' unknown, nothing sent")
 			except Exception as e:
 				print("mqtt_tx_energenie: Exception occurred")
 				print(e)

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -344,7 +344,7 @@ def main():
 	
 	# Bind event receiver for inbound energenie messages
 	print("Binding fsk_router.when_incoming to rx_energenie...")
-	energenie.fsk_router.when_incoming(rx_energenie)
+	#energenie.fsk_router.when_incoming(rx_energenie)
 
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting rx_energenie_process thread...")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -80,7 +80,7 @@ def rx_mqtt_on_connect(client, userdata, flags, rc):
 
 	print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic_subscribe + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 	# Send a status message so that watchers know what's going on
-	fromMqtt.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_connected, qos=1, retain=True)
+	client.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
 	# Set last will message, so if connection is lost watchers will know
 	client.will_set(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_lastwill, qos=1, retain=True)
@@ -114,10 +114,11 @@ def rx_mqtt():
 	global q_rx_mqtt
 	global rx_mqtt_client_connected
 
+	fromMqtt = mqtt.Client(client_id=mqtt_subscribe_client_id, clean_session=mqtt_clean_session)
+
 	print("rx_mqtt: Starting mqtt subscribing loop...")
 	while not programkiller.kill_now:
 		try:
-			fromMqtt = mqtt.Client(client_id=mqtt_subscribe_client_id, clean_session=mqtt_clean_session)
 			fromMqtt.on_connect = rx_mqtt_on_connect
 			fromMqtt.on_disconnect = rx_mqtt_on_disconnect
 			fromMqtt.on_subscribe = rx_mqtt_on_subscribe
@@ -245,7 +246,7 @@ def energenie_tx_mqtt():
 
 			print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 			# Send a status message so that watchers know what's going on
-			fromMqtt.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_connected, qos=1, retain=True)
+			client.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
 			# Set last will message, so if connection is lost watchers will know
 			client.will_set(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_lastwill, qos=1, retain=True)

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -349,21 +349,21 @@ def main():
 	thread_rxEnergenie = threading.Thread(target=rx_energenie_process)
 	thread_rxEnergenie.daemon = True
 	thread_rxEnergenie.start()
-	print("rx_energenie_process is in thread PID " + str(thread_rxEnergenie.get_native_id()))
+	print("rx_energenie_process is in thread PID " + str( thread_rxEnergenie.native_id ))
 	
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting energenie_tx_mqtt thread...")
 	thread_energenieTxMqtt = threading.Thread(target=energenie_tx_mqtt)
 	thread_energenieTxMqtt.daemon = True
 	thread_energenieTxMqtt.start()
-	print("energenie_tx_mqtt is in thread PID " + str(thread_energenieTxMqtt.get_native_id()))
+	print("energenie_tx_mqtt is in thread PID " + str( thread_energenieTxMqtt.native_id ))
 
 	# Start thread for receiving inbound mqtt messages, which will queue them for the other thread
 	print("Starting rxFromMqtt thread...")
 	thread_rxFromMqtt = threading.Thread(target=rx_mqtt)
 	thread_rxFromMqtt.daemon = True
 	thread_rxFromMqtt.start()
-	print("rx_mqtt is in thread PID " + str(thread_rxFromMqtt.get_native_id()))
+	print("rx_mqtt is in thread PID " + str( thread_rxFromMqtt.native_id ))
 
 	print("These are devices in the registry...")
 	names = energenie.registry.names()

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -5,7 +5,7 @@ import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
 from pyenergenie.src import energenie as energenie
-from pyenergenie.src import energenie.Devices as energenieDevices
+from pyenergenie.src.energenie import Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue
 import threading

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -87,12 +87,18 @@ def rx_mqtt():
 			if mqtt_username != "":
 				fromMqtt.username_pw_set(mqtt_username, mqtt_password)
 			
+			print("rx_mqtt: Connecting after this...")
 			fromMqtt.connect(mqtt_hostname, mqtt_port, mqtt_keepalive)
+
+			while not rx_mqtt_client_connected:
+				print("rx_mqtt: Looping until connected")
+				time.sleep(0.1)
 
 			# Blocking call that processes network traffic, dispatches callbacks and
 			# handles reconnecting.
 			# Other loop*() functions are available that give a threaded interface and a
 			# manual interface.
+			print("rx_mqtt: Looping forever after this...")
 			fromMqtt.loop_forever()
 		except Exception as e:
 			print("rx_mqtt: exception occurred")
@@ -115,13 +121,13 @@ def mqtt_tx_energenie():
 				print("mqtt_tx_energenie: " + name + " - on")
 				for x in range(0, 5):
 					device.turn_on()
-					print("mqtt_tx_energenie: " + name + " - on attempt " + x)
+					print("mqtt_tx_energenie: " + name + " - on attempt " + str(x))
 					time.sleep(0.1)
 			else:
 				print("mqtt_tx_energenie: " + name + " - off")
 				for x in range(0, 5):
 					device.turn_off()
-					print("mqtt_tx_energenie: " + name + " - off attempt " + x)
+					print("mqtt_tx_energenie: " + name + " - off attempt " + str(x))
 					time.sleep(0.1)
 		except Exception as e:
 			print("mqtt_tx_energenie: Exception occurred")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -158,8 +158,8 @@ def mqtt_tx_energenie(msg):
 		device = energenie.registry.get(name)
 		
 		if len(topic_parts) == 2 or action == "switch" or action == "":
-			if str(msg.payload) == "1":
-				print("mqtt_tx_energenie: " + name + " - switch - 1/on")
+			if str(msg.payload) == "1" or (str(msg.payload)).lower() == "true" or (str(msg.payload)).lower() == "on":
+				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/on")
 				device.turn_on()
 			else:
 				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/off")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -371,15 +371,15 @@ def main():
 	# Main processing loop for the energenie radio; loop command checks receive threads
 	while not programkiller.kill_now:
 		energenie.loop()
-		try:
-			msg = q_rx_mqtt.get(block=False,timeout=1)
-		except Queue.Empty as e:
-			# Empty queue means do nothing, just keep trying to receive
-			pass
-		else:
-			mqtt_tx_energenie(msg=msg)
+		# try:
+		# 	msg = q_rx_mqtt.get(block=False,timeout=1)
+		# except Queue.Empty as e:
+		# 	# Empty queue means do nothing, just keep trying to receive
+		# 	pass
+		# else:
+		# 	mqtt_tx_energenie(msg=msg)
 
-			q_rx_mqtt.task_done()
+		# 	q_rx_mqtt.task_done()
 
 
 if __name__ == "__main__":

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -372,7 +372,7 @@ def main():
 	while not programkiller.kill_now:
 		energenie.loop()
 		try:
-			msg = q_rx_mqtt.get(block=False)
+			msg = q_rx_mqtt.get(block=False,timeout=0.05)
 		except Queue.Empty as e:
 			# Empty queue means do nothing, just keep trying to receive
 			pass

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -346,21 +346,24 @@ def main():
 
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting rx_energenie_process thread...")
-	thread_rxProcessor = threading.Thread(target=rx_energenie_process)
-	thread_rxProcessor.daemon = True
-	thread_rxProcessor.start()
+	thread_rxEnergenie = threading.Thread(target=rx_energenie_process)
+	thread_rxEnergenie.daemon = True
+	thread_rxEnergenie.start()
+	print ("rx_energenie_process is in thread PID " + str(thread_rxEnergenie.get_native_id())
 	
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting energenie_tx_mqtt thread...")
-	thread_rxProcessor = threading.Thread(target=energenie_tx_mqtt)
-	thread_rxProcessor.daemon = True
-	thread_rxProcessor.start()
+	thread_energenieTxMqtt = threading.Thread(target=energenie_tx_mqtt)
+	thread_energenieTxMqtt.daemon = True
+	thread_energenieTxMqtt.start()
+	print ("energenie_tx_mqtt is in thread PID " + str(thread_energenieTxMqtt.get_native_id())
 
 	# Start thread for receiving inbound mqtt messages, which will queue them for the other thread
 	print("Starting rxFromMqtt thread...")
-	thread_rxProcessor = threading.Thread(target=rx_mqtt)
-	thread_rxProcessor.daemon = True
-	thread_rxProcessor.start()
+	thread_rxFromMqtt = threading.Thread(target=rx_mqtt)
+	thread_rxFromMqtt.daemon = True
+	thread_rxFromMqtt.start()
+	print ("rx_mqtt is in thread PID " + str(thread_rxFromMqtt.get_native_id())
 
 	print("These are devices in the registry...")
 	names = energenie.registry.names()

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -372,7 +372,7 @@ def main():
 	while not programkiller.kill_now:
 		energenie.loop()
 		try:
-			msg = q_rx_mqtt.get(block=False,timeout=0.2)
+			msg = q_rx_mqtt.get(block=False,timeout=1)
 		except Queue.Empty as e:
 			# Empty queue means do nothing, just keep trying to receive
 			pass

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -349,21 +349,21 @@ def main():
 	thread_rxEnergenie = threading.Thread(target=rx_energenie_process)
 	thread_rxEnergenie.daemon = True
 	thread_rxEnergenie.start()
-	print ("rx_energenie_process is in thread PID " + str(thread_rxEnergenie.get_native_id())
+	print("rx_energenie_process is in thread PID " + str(thread_rxEnergenie.get_native_id()))
 	
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting energenie_tx_mqtt thread...")
 	thread_energenieTxMqtt = threading.Thread(target=energenie_tx_mqtt)
 	thread_energenieTxMqtt.daemon = True
 	thread_energenieTxMqtt.start()
-	print ("energenie_tx_mqtt is in thread PID " + str(thread_energenieTxMqtt.get_native_id())
+	print("energenie_tx_mqtt is in thread PID " + str(thread_energenieTxMqtt.get_native_id()))
 
 	# Start thread for receiving inbound mqtt messages, which will queue them for the other thread
 	print("Starting rxFromMqtt thread...")
 	thread_rxFromMqtt = threading.Thread(target=rx_mqtt)
 	thread_rxFromMqtt.daemon = True
 	thread_rxFromMqtt.start()
-	print ("rx_mqtt is in thread PID " + str(thread_rxFromMqtt.get_native_id())
+	print("rx_mqtt is in thread PID " + str(thread_rxFromMqtt.get_native_id()))
 
 	print("These are devices in the registry...")
 	names = energenie.registry.names()

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -49,15 +49,14 @@ def rx_mqtt():
 	global mqtt_subscribe_topic
 	global q_rx_mqtt
 
-	global rx_mqtt_client_connected = False
+	rx_mqtt_client_connected = False
 
 	# The callback for when the client receives a CONNACK response from the server.
 	def rx_mqtt_on_connect(client, userdata, flags, rc):
 		global mqtt_subscribe_topic
-		global rx_mqtt_client_connected
 
 		print("rx_mqtt: Connected with result code " + str(rc))
-		rx_mqtt_client_connected = True
+		rx_mqtt.rx_mqtt_client_connected = True
 		print("rx_mqtt: Setting rx_mqtt_client_connected = True")
 		# TODO: Add the on_disconnect logic, and a loop to ensure we're always connected
 
@@ -67,8 +66,7 @@ def rx_mqtt():
 		client.subscribe(mqtt_subscribe_topic + "/#")
 	
 	def rx_mqtt_on_disconnect(client, userdata, flags, rc):
-		global rx_mqtt_client_connected
-		rx_mqtt_client_connected = False
+		rx_mqtt.rx_mqtt_client_connected = False
 		print("rx_mqtt: Disconnected with result code " + str(rc))
 
 	# The callback for when a PUBLISH message is received from the server.

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -141,7 +141,7 @@ def rx_energenie(address, message):
 			# Check if the message is from the current device of this iteration
 			if address[2] == d.get_device_id():
 				# Yes we found the device, so add to processing queue
-				print("rx_energenie: Queuing message from " + str(address) + " - " + devicename)
+				#print("rx_energenie: Queuing message from " + str(address) + " - " + devicename)
 				newQueueEntry = {'DeviceName': devicename, 'DeviceType': address[1]}
 				q_rx_energenie.put(newQueueEntry)
 				# The device was found, so break from the for loop
@@ -156,11 +156,11 @@ def rx_energenie_process():
 
 	while True:
 		try:
-			print("rx_energenie_process: awaiting item in q_rx_energenie...")
+			#print("rx_energenie_process: awaiting item in q_rx_energenie...")
 			refreshed_device = q_rx_energenie.get()
 			d = energenie.registry.get( refreshed_device['DeviceName'] )
 
-			print("rx_energenie_process: processing message from " + refreshed_device['DeviceName'] + " (type: " + str(refreshed_device['DeviceType']) + ")...")
+			#print("rx_energenie_process: processing message from " + refreshed_device['DeviceName'] + " (type: " + str(refreshed_device['DeviceType']) + ")...")
 			#if refreshed_device['DeviceType'] == PRODUCTID_MIHO006:
 			#	try:
 			#		p = d.get_apparent_power()
@@ -253,10 +253,10 @@ def energenie_tx_mqtt():
 		
 		while True:
 			try:
-				print("energenie_tx_mqtt: awaiting item in q_tx_mqtt...")
+				#print("energenie_tx_mqtt: awaiting item in q_tx_mqtt...")
 				item = q_tx_mqtt.get()
 
-				print("energenie_tx_mqtt: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
+				#print("energenie_tx_mqtt: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
 				print(str(item))
 
 				data = item['data']

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -4,8 +4,8 @@
 import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
-import pyenergenie.src.energenie as energenie
-import pyenergenie.src.energenie.Devices as energenieDevices
+from pyenergenie.src import energenie as energenie
+from pyenergenie.src import energenie.Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue
 import threading

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -63,25 +63,22 @@ class GracefulKiller:
 
 programkiller = GracefulKiller()
 
-def getPid():
-	return threading.current_thread().ident
-
 
 # The callback for when the client receives a CONNACK response from the server.
 def rx_mqtt_on_connect(client, userdata, flags, rc):
 	global mqtt_subscribe_topic
 	global rx_mqtt_client_connected
 
-	print("rx_mqtt [%s]: Connected to %s:%s with result code %s" % (getPid(), client._host, client._port, rc))
+	print("rx_mqtt: Connected to %s:%s with result code %s" % (client._host, client._port, rc))
 	rx_mqtt_client_connected = True
-	print("rx_mqtt [" + getPid() + "]: Set rx_mqtt_client_connected as True = " + str(rx_mqtt_client_connected))
+	print("rx_mqtt: Set rx_mqtt_client_connected as True = " + str(rx_mqtt_client_connected))
 
 	# Subscribing in on_connect() means that if we lose the connection and
 	# reconnect then subscriptions will be renewed.
-	print("rx_mqtt [" + getPid() + "]: Subscribing to " + mqtt_subscribe_topic + "/#")
+	print("rx_mqtt: Subscribing to " + mqtt_subscribe_topic + "/#")
 	client.subscribe(mqtt_subscribe_topic + "/#")
 
-	print("rx_mqtt [" + getPid() + "]: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic_subscribe + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
+	print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic_subscribe + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 	# Send a status message so that watchers know what's going on
 	client.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
@@ -91,12 +88,12 @@ def rx_mqtt_on_connect(client, userdata, flags, rc):
 def rx_mqtt_on_disconnect(client, userdata, flags, rc):
 	global rx_mqtt_client_connected
 	rx_mqtt_client_connected = False
-	print("rx_mqtt [" + getPid() + "]: Disconnected with result code " + str(rc))
-	print("rx_mqtt [" + getPid() + "]: Stopping mqtt subscribe client loop...")
+	print("rx_mqtt: Disconnected with result code " + str(rc))
+	print("rx_mqtt: Stopping mqtt subscribe client loop...")
 	client.loop_stop()
 
 def rx_mqtt_on_subscribe(client, userdata, mid, granted_qos):
-	print("rx_mqtt_on_subscribe [" + getPid() + "]: Subcribed for receiving mqtt - " + str(mid) + " with QoS="+str(granted_qos))
+	print("rx_mqtt_on_subscribe: Subcribed for receiving mqtt - " + str(mid) + " with QoS="+str(granted_qos))
 
 # The callback for when a PUBLISH message is received from the server.
 def rx_mqtt_on_message(client, userdata, msg):
@@ -119,7 +116,7 @@ def rx_mqtt():
 
 	fromMqtt = mqtt.Client(client_id=mqtt_subscribe_client_id, clean_session=mqtt_clean_session)
 
-	print("rx_mqtt [" + getPid() + "]: Starting mqtt subscribing loop...")
+	print("rx_mqtt: Starting mqtt subscribing loop...")
 	while not programkiller.kill_now:
 		try:
 			fromMqtt.on_connect = rx_mqtt_on_connect
@@ -130,31 +127,31 @@ def rx_mqtt():
 			if mqtt_username != "":
 				fromMqtt.username_pw_set(mqtt_username, mqtt_password)
 			
-			print("rx_mqtt [" + getPid() + "]: Connecting after this...")
+			print("rx_mqtt: Connecting after this...")
 			fromMqtt.connect(mqtt_hostname, mqtt_port, mqtt_keepalive)
 
 			# Blocking call that processes network traffic, dispatches callbacks and
 			# handles reconnecting.
 			# Other loop*() functions are available that give a threaded interface and a
 			# manual interface.
-			print("rx_mqtt [" + getPid() + "]: Looping forever after this...")
+			print("rx_mqtt: Looping forever after this...")
 			while not programkiller.kill_now:
 				fromMqtt.loop(timeout=0.2)
 		except Exception as e:
-			print("rx_mqtt [" + getPid() + "]: exception occurred")
+			print("rx_mqtt: exception occurred")
 			print(e)
 		finally:
 			if not programkiller.kill_now:
-				print("rx_mqtt [" + getPid() + "]: Restarting...")
+				print("rx_mqtt: Restarting...")
 	
-	print("rx_mqtt [" + getPid() + "]: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic_subscribe + "' then disconnecting...")
+	print("rx_mqtt: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic_subscribe + "' then disconnecting...")
 	fromMqtt.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_disconnected, qos=1, retain=True)
 	fromMqtt.disconnect()
 
 
 def mqtt_tx_energenie(msg):
 	try:
-		print("mqtt_tx_energenie [" + getPid() + "]: " + msg.topic + " " + str(msg.payload))
+		print("mqtt_tx_energenie: " + msg.topic + " " + str(msg.payload))
 
 		topic_parts = msg.topic.split("/", 3)
 		name = topic_parts[1]
@@ -163,30 +160,30 @@ def mqtt_tx_energenie(msg):
 		
 		if len(topic_parts) == 2 or action == "switch" or action == "":
 			if str(msg.payload) == "1" or (str(msg.payload)).lower() == "true" or (str(msg.payload)).lower() == "on":
-				print("mqtt_tx_energenie [" + getPid() + "]: " + name + " - switch - " + str(msg.payload) + "/on")
+				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/on")
 				device.turn_on()
 			else:
-				print("mqtt_tx_energenie [" + getPid() + "]: " + name + " - switch - " + str(msg.payload) + "/off")
+				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/off")
 				device.turn_off()
 		#elif action == "otheractionnamehere":
-		#	print("mqtt_tx_energenie [" + getPid() + "]: action '" + action + "' for '" + name + "' containing '" + msg.payload + "'" )
+		#	print("mqtt_tx_energenie: action '" + action + "' for '" + name + "' containing '" + msg.payload + "'" )
 		else:
 			# Action not found
-			print("mqtt_tx_energenie [" + getPid() + "]: action '" + action + "' unknown, nothing sent")
+			print("mqtt_tx_energenie: action '" + action + "' unknown, nothing sent")
 	except Exception as e:
-		print("mqtt_tx_energenie [" + getPid() + "]: Exception occurred")
+		print("mqtt_tx_energenie: Exception occurred")
 		print(e)
 
 
 def rx_energenie(address, message):
 	global q_rx_energenie
 
-	#print("rx_energenie [" + getPid() + "]: new message from " + str(address) )
+	#print("rx_energenie: new message from " + str(address) )
 
 	if address[0] == MFRID_ENERGENIE:
 		# Retrieve list of names from the registry, so we can refer to the name of the device
 		for devicename in energenie.registry.names():
-			#print("rx_energenie [" + getPid() + "]: checking if message from " + devicename)
+			#print("rx_energenie: checking if message from " + devicename)
 
 			# Using the name, retrieve the device
 			d = energenie.registry.get(devicename)
@@ -194,13 +191,13 @@ def rx_energenie(address, message):
 			# Check if the message is from the current device of this iteration
 			if address[2] == d.get_device_id():
 				# Yes we found the device, so add to processing queue
-				#print("rx_energenie [" + getPid() + "]: Queuing message from " + str(address) + " - " + devicename)
+				#print("rx_energenie: Queuing message from " + str(address) + " - " + devicename)
 				newQueueEntry = {'DeviceName': devicename, 'DeviceType': address[1]}
 				q_rx_energenie.put(newQueueEntry)
 				# The device was found, so break from the for loop
 				break
 	else:
-		print("rx_energenie [" + getPid() + "]: Not an energenie device " + str(address))
+		print("rx_energenie: Not an energenie device " + str(address))
 
 
 
@@ -209,7 +206,7 @@ def rx_energenie_process():
 
 	while True:
 		try:
-			#print("rx_energenie_process [" + getPid() + "]: awaiting item in q_rx_energenie...")
+			#print("rx_energenie_process: awaiting item in q_rx_energenie...")
 			refreshed_device = q_rx_energenie.get()
 			d = energenie.registry.get( refreshed_device['DeviceName'] )
 
@@ -222,7 +219,7 @@ def rx_energenie_process():
 
 			q_rx_energenie.task_done()
 		except Exception as e:
-			print("rx_energenie_process [" + getPid() + "]: exception occurred")
+			print("rx_energenie_process: exception occurred")
 			print(e)
 
 
@@ -243,33 +240,33 @@ def energenie_tx_mqtt():
 	def energenie_tx_mqtt_on_connect(client, userdata, flags, rc):
 		global energenie_tx_mqtt_client_connected
 		if rc == 0:
-			#print("energenie_tx_mqtt [" + getPid() + "]: client connected")
+			#print("energenie_tx_mqtt: client connected")
 			client.is_connected = True
 			energenie_tx_mqtt_client_connected = True
 
-			print("rx_mqtt [" + getPid() + "]: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
+			print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 			# Send a status message so that watchers know what's going on
 			client.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
 			# Set last will message, so if connection is lost watchers will know
 			client.will_set(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_lastwill, qos=1, retain=True)
 		else:
-			print("energenie_tx_mqtt [" + getPid() + "]: Bad connection; rc = "+str(rc))
+			print("energenie_tx_mqtt: Bad connection; rc = "+str(rc))
 	
 	def energenie_tx_mqtt_on_disconnect(client, userdata, rc):
 		global energenie_tx_mqtt_client_connected
-		#print("energenie_tx_mqtt [" + getPid() + "]: client disconnected " + str(rc))
+		#print("energenie_tx_mqtt: client disconnected " + str(rc))
 		client.is_connected = False
 		energenie_tx_mqtt_client_connected = False
 		#client.loop_stop()
 	
 	def energenie_tx_mqtt_on_publish(client, userdata, mid):
-		#print("energenie_tx_mqtt [" + getPid() + "]: publish of " + str(mid) + " successful")
+		#print("energenie_tx_mqtt: publish of " + str(mid) + " successful")
 		pass
 
 	#TODO: Move client instantiation outside of loop, manage connection status with single object
 	while True:
-		print("energenie_tx_mqtt [" + getPid() + "]: creating mqtt.client...")
+		print("energenie_tx_mqtt: creating mqtt.client...")
 		toMqtt = mqtt.Client(client_id=mqtt_client_id, clean_session=mqtt_clean_session)
 		toMqtt.is_connected = False
 		toMqtt.on_connect = energenie_tx_mqtt_on_connect
@@ -277,23 +274,23 @@ def energenie_tx_mqtt():
 		toMqtt.on_publish = energenie_tx_mqtt_on_publish
 
 		if mqtt_username <> "":
-			print("energenie_tx_mqtt [" + getPid() + "]: using username and password...")
+			print("energenie_tx_mqtt: using username and password...")
 			toMqtt.username_pw_set(mqtt_username, mqtt_password)
-		print("energenie_tx_mqtt [" + getPid() + "]: connecting to mqtt broker...")
+		print("energenie_tx_mqtt: connecting to mqtt broker...")
 		toMqtt.connect(mqtt_hostname, mqtt_port, mqtt_keepalive)
-		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.loop_start() thread starting...")
+		print("energenie_tx_mqtt: toMqtt.loop_start() thread starting...")
 		toMqtt.loop_start()
 
 		#while not toMqtt.is_connected:
-		#	print("energenie_tx_mqtt [" + getPid() + "]: waiting to ensure connection...")
+		#	print("energenie_tx_mqtt: waiting to ensure connection...")
 		#	time.sleep(0.5)
 		
 		while not programkiller.kill_now:
 			try:
-				#print("energenie_tx_mqtt [" + getPid() + "]: awaiting item in q_tx_mqtt...")
+				#print("energenie_tx_mqtt: awaiting item in q_tx_mqtt...")
 				item = q_tx_mqtt.get(block=False, timeout=0.2)
 
-				#print("energenie_tx_mqtt [" + getPid() + "]: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
+				#print("energenie_tx_mqtt: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
 				#print(str(item))
 
 				data = item['data']
@@ -306,28 +303,28 @@ def energenie_tx_mqtt():
 						value = ""
 
 					publish_topic = mqtt_publish_topic + "/" + item['DeviceName'] + "/" + metric
-					#print("energenie_tx_mqtt [" + getPid() + "]: publishing '" + str( value ) + "' to topic " + publish_topic)
+					#print("energenie_tx_mqtt: publishing '" + str( value ) + "' to topic " + publish_topic)
 					publish_result = toMqtt.publish(publish_topic, value)
-					#print("energenie_tx_mqtt [" + getPid() + "]: publish returned " + str(publish_result[1]))
+					#print("energenie_tx_mqtt: publish returned " + str(publish_result[1]))
 				q_tx_mqtt.task_done()
 			except Queue.Empty as e:
 				# Empty queue means no payloads pending to be sent, so just loop again
 				pass
 			except Exception as e:
-				print("energenie_tx_mqtt [" + getPid() + "]: exception occurred")
+				print("energenie_tx_mqtt: exception occurred")
 				print(e)
 				if not toMqtt.is_connected:
-					print("energenie_tx_mqtt [" + getPid() + "]: mqtt client no longer connected, breaking processing loop")
+					print("energenie_tx_mqtt: mqtt client no longer connected, breaking processing loop")
 					break
 		
-		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.is_connected == " + str(toMqtt.is_connected))
-		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.loop_stop()")
+		print("energenie_tx_mqtt: toMqtt.is_connected == " + str(toMqtt.is_connected))
+		print("energenie_tx_mqtt: toMqtt.loop_stop()")
 		toMqtt.loop_stop()
 		if not programkiller.kill_now:
-			print("energenie_tx_mqtt [" + getPid() + "]: sleeping for 5 seconds before restarting thread")
+			print("energenie_tx_mqtt: sleeping for 5 seconds before restarting thread")
 			time.sleep(5)
 		else:
-			print("rx_mqtt [" + getPid() + "]: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic + "' then disconnecting...")
+			print("rx_mqtt: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic + "' then disconnecting...")
 			toMqtt.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_disconnected, qos=1, retain=True)
 			toMqtt.disconnect()
 			break

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -4,7 +4,7 @@
 import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
-import pyenergenie.src.energenie as energenie
+from pyenergenie.src import energenie as energenie
 from pyenergenie.src.energenie import Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -346,24 +346,21 @@ def main():
 
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting rx_energenie_process thread...")
-	thread_rxEnergenie = threading.Thread(target=rx_energenie_process)
+	thread_rxEnergenie = threading.Thread(target=rx_energenie_process, name="rx_energenie_process")
 	thread_rxEnergenie.daemon = True
 	thread_rxEnergenie.start()
-	print("rx_energenie_process is in thread PID " + str( thread_rxEnergenie.native_id ))
 	
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting energenie_tx_mqtt thread...")
-	thread_energenieTxMqtt = threading.Thread(target=energenie_tx_mqtt)
+	thread_energenieTxMqtt = threading.Thread(target=energenie_tx_mqtt, name="energenie_tx_mqtt")
 	thread_energenieTxMqtt.daemon = True
 	thread_energenieTxMqtt.start()
-	print("energenie_tx_mqtt is in thread PID " + str( thread_energenieTxMqtt.native_id ))
 
 	# Start thread for receiving inbound mqtt messages, which will queue them for the other thread
 	print("Starting rxFromMqtt thread...")
-	thread_rxFromMqtt = threading.Thread(target=rx_mqtt)
+	thread_rxFromMqtt = threading.Thread(target=rx_mqtt, name="rx_mqtt")
 	thread_rxFromMqtt.daemon = True
 	thread_rxFromMqtt.start()
-	print("rx_mqtt is in thread PID " + str( thread_rxFromMqtt.native_id ))
 
 	print("These are devices in the registry...")
 	names = energenie.registry.names()

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -81,7 +81,7 @@ def rx_mqtt():
 		try:
 			fromMqtt = mqtt.Client(client_id=mqtt_client_id, clean_session=mqtt_clean_session)
 			fromMqtt.on_connect = rx_mqtt_on_connect
-			fromMqtt.on_disconnect = rx_mqtt_ondisconnect
+			fromMqtt.on_disconnect = rx_mqtt_on_disconnect
 			fromMqtt.on_message = rx_mqtt_on_message
 
 			if mqtt_username != "":

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -344,7 +344,7 @@ def main():
 	
 	# Bind event receiver for inbound energenie messages
 	print("Binding fsk_router.when_incoming to rx_energenie...")
-	#energenie.fsk_router.when_incoming(rx_energenie)
+	energenie.fsk_router.when_incoming(rx_energenie)
 
 	# Start thread for processing received inbound energenie, then sending to mqtt
 	print("Starting rx_energenie_process thread...")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -4,7 +4,7 @@
 import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
-from pyenergenie.src import energenie as energenie
+from pyenergenie.src.energenie import energenie as energenie
 from pyenergenie.src.energenie import Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -121,7 +121,7 @@ def mqtt_tx_energenie():
 				print("mqtt_tx_energenie: " + name + " - off")
 				for x in range(0, 5):
 					device.turn_off()
-					print("mqtt_tx_energenie: " + name + " - off attempt " + x
+					print("mqtt_tx_energenie: " + name + " - off attempt " + x)
 					time.sleep(0.1)
 		except Exception as e:
 			print("mqtt_tx_energenie: Exception occurred")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -40,6 +40,8 @@ q_tx_mqtt = Queue.Queue()
 q_tx_energenie = Queue.Queue()
 
 rx_mqtt_client_connected = False
+wait_for_energenie_tx = False
+receive_paused_for_energenie_tx = False
 
 # The callback for when the client receives a CONNACK response from the server.
 def rx_mqtt_on_connect(client, userdata, flags, rc):
@@ -349,6 +351,7 @@ def main():
 
 	while True:
 		energenie.loop()
+		time.sleep(0.25)
 
 
 if __name__ == "__main__":

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -348,7 +348,7 @@ def main():
 		device = energenie.registry.get(name)
 
 	while True:
-		#energenie.loop()
+		energenie.loop()
 		time.sleep(0.25)
 
 

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -349,17 +349,6 @@ def main():
 	global mqtt_client_id
 	global mqtt_clean_session
 	global energenie_devices
-
-	print("Iterating devices in registry so they bind to receive router, and adding to energenie_devices dict for future easy reference...")
-	names = energenie.registry.names()
-	for name in names:
-		print( "...Binding device " + name + "...")
-		device = energenie.registry.get(name)
-		# Used by rx_energenie to have a handy device name and device object, since the registry does this oddly
-		energenie_devices[device.get_device_id()] = {
-			"name": name,
-			"device": device
-		}
 	
 	# Bind event receiver for inbound energenie messages
 	print("Binding fsk_router.when_incoming to rx_energenie...")
@@ -382,6 +371,17 @@ def main():
 	thread_rxFromMqtt = threading.Thread(target=rx_mqtt, name="rx_mqtt")
 	thread_rxFromMqtt.daemon = True
 	thread_rxFromMqtt.start()
+
+	print("Iterating devices in registry so they bind to receive router, and adding to energenie_devices dict for future easy reference...")
+	names = energenie.registry.names()
+	for name in names:
+		print( "...Binding device " + name + "...")
+		device = energenie.registry.get(name)
+		# Used by rx_energenie to have a handy device name and device object, since the registry does this oddly
+		energenie_devices[device.get_device_id()] = {
+			"name": name,
+			"device": device
+		}
 
 	print("Starting main receiver loop...")
 	# Main processing loop for the energenie radio; loop command checks receive threads

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -187,8 +187,8 @@ def rx_energenie(address, message):
 
 	if address[0] == MFRID_ENERGENIE:
 		if address[2] in energenie_devices:
-			devicename = energenie_devices[address[2]].name
-			d = energenie_devices[address[2]].device
+			devicename = energenie_devices[address[2]]['name']
+			d = energenie_devices[address[2]]['device']
 			#print("rx_energenie: checking if message from " + devicename)
 
 			# Check if the message is from the current device of this iteration
@@ -212,7 +212,7 @@ def rx_energenie_process():
 		try:
 			#print("rx_energenie_process: awaiting item in q_rx_energenie...")
 			refreshed_device = q_rx_energenie.get()
-			d = energenie_devices[ refreshed_device['DeviceId'] ].device
+			d = energenie_devices[ refreshed_device['DeviceId'] ]['device']
 
 			item = {
 				'DeviceId': refreshed_device['DeviceId'],
@@ -379,8 +379,8 @@ def main():
 		device = energenie.registry.get(name)
 		# Used by rx_energenie to have a handy device name and device object, since the registry does this oddly
 		energenie_devices[device.get_device_id()] = {
-			"name": name,
-			"device": device
+			'name': name,
+			'device': device
 		}
 
 	print("Starting main receiver loop...")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -49,11 +49,12 @@ def rx_mqtt():
 	global mqtt_subscribe_topic
 	global q_rx_mqtt
 
-	rx_mqtt_client_connected = False
+	global rx_mqtt_client_connected = False
 
 	# The callback for when the client receives a CONNACK response from the server.
 	def rx_mqtt_on_connect(client, userdata, flags, rc):
 		global mqtt_subscribe_topic
+		global rx_mqtt_client_connected
 
 		print("rx_mqtt: Connected with result code " + str(rc))
 		rx_mqtt_client_connected = True
@@ -66,6 +67,7 @@ def rx_mqtt():
 		client.subscribe(mqtt_subscribe_topic + "/#")
 	
 	def rx_mqtt_on_disconnect(client, userdata, flags, rc):
+		global rx_mqtt_client_connected
 		rx_mqtt_client_connected = False
 		print("rx_mqtt: Disconnected with result code " + str(rc))
 

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -3,9 +3,9 @@
 # - https://github.com/whaleygeek/pyenergenie/blob/master/src/mihome_energy_monitor.py
 import sys
 import time
-#sys.path.insert(0, '/shared/pyenergenie-master/src')
-from pyenergenie.src import energenie as energenie
-from pyenergenie.src.energenie import Devices as energenieDevices
+sys.path.insert(0, './pyenergenie/src')
+import energenie as energenie
+import energenie.Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue
 import threading

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -40,8 +40,6 @@ q_tx_mqtt = Queue.Queue()
 q_tx_energenie = Queue.Queue()
 
 rx_mqtt_client_connected = False
-wait_for_energenie_tx = False
-receive_paused_for_energenie_tx = False
 
 # The callback for when the client receives a CONNACK response from the server.
 def rx_mqtt_on_connect(client, userdata, flags, rc):

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -349,6 +349,17 @@ def main():
 	global mqtt_client_id
 	global mqtt_clean_session
 	global energenie_devices
+
+	print("Iterating devices in registry so they bind to receive router, and adding to energenie_devices dict for future easy reference...")
+	names = energenie.registry.names()
+	for name in names:
+		print( "...Binding device " + name + "...")
+		device = energenie.registry.get(name)
+		# Used by rx_energenie to have a handy device name and device object, since the registry does this oddly
+		energenie_devices[device.get_device_id()] = {
+			"name": name,
+			"device": device
+		}
 	
 	# Bind event receiver for inbound energenie messages
 	print("Binding fsk_router.when_incoming to rx_energenie...")
@@ -371,17 +382,6 @@ def main():
 	thread_rxFromMqtt = threading.Thread(target=rx_mqtt, name="rx_mqtt")
 	thread_rxFromMqtt.daemon = True
 	thread_rxFromMqtt.start()
-
-	print("Iterating devices in registry so they bind to receive router, and adding to energenie_devices dict for future easy reference...")
-	names = energenie.registry.names()
-	for name in names:
-		print( "...Binding device " + name + "...")
-		device = energenie.registry.get(name)
-		# Used by rx_energenie to have a handy device name and device object, since the registry does this oddly
-		energenie_devices[device.get_device_id()] = {
-			"name": name,
-			"device": device
-		}
 
 	print("Starting main receiver loop...")
 	# Main processing loop for the energenie radio; loop command checks receive threads

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -36,7 +36,7 @@ PRODUCTID_MIHO033                 = 0x0D    # FSK open sensor
 q_rx_mqtt = Queue.Queue()
 q_rx_energenie = Queue.Queue()
 q_tx_mqtt = Queue.Queue()
-q_tx_energenie = Queue.Queue() # Not yet in use, TODO
+q_tx_energenie = Queue.Queue()
 
 def rx_mqtt():
 	global mqtt_hostname
@@ -67,7 +67,7 @@ def rx_mqtt():
 	
 	def rx_mqtt_on_disconnect(client, userdata, flags, rc):
 		rx_mqtt_client_connected = False
-		print("rx_mqtt: Disonnected with result code " + str(rc))
+		print("rx_mqtt: Disconnected with result code " + str(rc))
 
 	# The callback for when a PUBLISH message is received from the server.
 	def rx_mqtt_on_message(client, userdata, msg):
@@ -80,9 +80,9 @@ def rx_mqtt():
 	while True:
 		try:
 			fromMqtt = mqtt.Client(client_id=mqtt_client_id, clean_session=mqtt_clean_session)
-			fromMqtt.on_connect = on_connect
-			fromMqtt.on_disconnect
-			fromMqtt.on_message = on_message
+			fromMqtt.on_connect = rx_mqtt_on_connect
+			fromMqtt.on_disconnect = rx_mqtt_ondisconnect
+			fromMqtt.on_message = rx_mqtt_on_message
 
 			if mqtt_username != "":
 				fromMqtt.username_pw_set(mqtt_username, mqtt_password)

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -115,11 +115,13 @@ def mqtt_tx_energenie():
 				print("mqtt_tx_energenie: " + name + " - on")
 				for x in range(0, 5):
 					device.turn_on()
+					print("mqtt_tx_energenie: " + name + " - on attempt " + x)
 					time.sleep(0.1)
 			else:
 				print("mqtt_tx_energenie: " + name + " - off")
 				for x in range(0, 5):
 					device.turn_off()
+					print("mqtt_tx_energenie: " + name + " - off attempt " + x
 					time.sleep(0.1)
 		except Exception as e:
 			print("mqtt_tx_energenie: Exception occurred")

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -63,22 +63,25 @@ class GracefulKiller:
 
 programkiller = GracefulKiller()
 
+def getPid():
+	return threading.current_thread().ident
+
 
 # The callback for when the client receives a CONNACK response from the server.
 def rx_mqtt_on_connect(client, userdata, flags, rc):
 	global mqtt_subscribe_topic
 	global rx_mqtt_client_connected
 
-	print("rx_mqtt: Connected to %s:%s with result code %s" % (client._host, client._port, rc))
+	print("rx_mqtt [%s]: Connected to %s:%s with result code %s" % (getPid(), client._host, client._port, rc))
 	rx_mqtt_client_connected = True
-	print("rx_mqtt: Set rx_mqtt_client_connected as True = " + str(rx_mqtt_client_connected))
+	print("rx_mqtt [" + getPid() + "]: Set rx_mqtt_client_connected as True = " + str(rx_mqtt_client_connected))
 
 	# Subscribing in on_connect() means that if we lose the connection and
 	# reconnect then subscriptions will be renewed.
-	print("rx_mqtt: Subscribing to " + mqtt_subscribe_topic + "/#")
+	print("rx_mqtt [" + getPid() + "]: Subscribing to " + mqtt_subscribe_topic + "/#")
 	client.subscribe(mqtt_subscribe_topic + "/#")
 
-	print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic_subscribe + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
+	print("rx_mqtt [" + getPid() + "]: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic_subscribe + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 	# Send a status message so that watchers know what's going on
 	client.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
@@ -88,12 +91,12 @@ def rx_mqtt_on_connect(client, userdata, flags, rc):
 def rx_mqtt_on_disconnect(client, userdata, flags, rc):
 	global rx_mqtt_client_connected
 	rx_mqtt_client_connected = False
-	print("rx_mqtt: Disconnected with result code " + str(rc))
-	print("rx_mqtt: Stopping mqtt subscribe client loop...")
+	print("rx_mqtt [" + getPid() + "]: Disconnected with result code " + str(rc))
+	print("rx_mqtt [" + getPid() + "]: Stopping mqtt subscribe client loop...")
 	client.loop_stop()
 
 def rx_mqtt_on_subscribe(client, userdata, mid, granted_qos):
-	print("rx_mqtt_on_subscribe: Subcribed for receiving mqtt - " + str(mid) + " with QoS="+str(granted_qos))
+	print("rx_mqtt_on_subscribe [" + getPid() + "]: Subcribed for receiving mqtt - " + str(mid) + " with QoS="+str(granted_qos))
 
 # The callback for when a PUBLISH message is received from the server.
 def rx_mqtt_on_message(client, userdata, msg):
@@ -116,7 +119,7 @@ def rx_mqtt():
 
 	fromMqtt = mqtt.Client(client_id=mqtt_subscribe_client_id, clean_session=mqtt_clean_session)
 
-	print("rx_mqtt: Starting mqtt subscribing loop...")
+	print("rx_mqtt [" + getPid() + "]: Starting mqtt subscribing loop...")
 	while not programkiller.kill_now:
 		try:
 			fromMqtt.on_connect = rx_mqtt_on_connect
@@ -127,31 +130,31 @@ def rx_mqtt():
 			if mqtt_username != "":
 				fromMqtt.username_pw_set(mqtt_username, mqtt_password)
 			
-			print("rx_mqtt: Connecting after this...")
+			print("rx_mqtt [" + getPid() + "]: Connecting after this...")
 			fromMqtt.connect(mqtt_hostname, mqtt_port, mqtt_keepalive)
 
 			# Blocking call that processes network traffic, dispatches callbacks and
 			# handles reconnecting.
 			# Other loop*() functions are available that give a threaded interface and a
 			# manual interface.
-			print("rx_mqtt: Looping forever after this...")
+			print("rx_mqtt [" + getPid() + "]: Looping forever after this...")
 			while not programkiller.kill_now:
 				fromMqtt.loop(timeout=0.2)
 		except Exception as e:
-			print("rx_mqtt: exception occurred")
+			print("rx_mqtt [" + getPid() + "]: exception occurred")
 			print(e)
 		finally:
 			if not programkiller.kill_now:
-				print("rx_mqtt: Restarting...")
+				print("rx_mqtt [" + getPid() + "]: Restarting...")
 	
-	print("rx_mqtt: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic_subscribe + "' then disconnecting...")
+	print("rx_mqtt [" + getPid() + "]: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic_subscribe + "' then disconnecting...")
 	fromMqtt.publish(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_disconnected, qos=1, retain=True)
 	fromMqtt.disconnect()
 
 
 def mqtt_tx_energenie(msg):
 	try:
-		print("mqtt_tx_energenie: " + msg.topic + " " + str(msg.payload))
+		print("mqtt_tx_energenie [" + getPid() + "]: " + msg.topic + " " + str(msg.payload))
 
 		topic_parts = msg.topic.split("/", 3)
 		name = topic_parts[1]
@@ -160,30 +163,30 @@ def mqtt_tx_energenie(msg):
 		
 		if len(topic_parts) == 2 or action == "switch" or action == "":
 			if str(msg.payload) == "1" or (str(msg.payload)).lower() == "true" or (str(msg.payload)).lower() == "on":
-				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/on")
+				print("mqtt_tx_energenie [" + getPid() + "]: " + name + " - switch - " + str(msg.payload) + "/on")
 				device.turn_on()
 			else:
-				print("mqtt_tx_energenie: " + name + " - switch - " + str(msg.payload) + "/off")
+				print("mqtt_tx_energenie [" + getPid() + "]: " + name + " - switch - " + str(msg.payload) + "/off")
 				device.turn_off()
 		#elif action == "otheractionnamehere":
-		#	print("mqtt_tx_energenie: action '" + action + "' for '" + name + "' containing '" + msg.payload + "'" )
+		#	print("mqtt_tx_energenie [" + getPid() + "]: action '" + action + "' for '" + name + "' containing '" + msg.payload + "'" )
 		else:
 			# Action not found
-			print("mqtt_tx_energenie: action '" + action + "' unknown, nothing sent")
+			print("mqtt_tx_energenie [" + getPid() + "]: action '" + action + "' unknown, nothing sent")
 	except Exception as e:
-		print("mqtt_tx_energenie: Exception occurred")
+		print("mqtt_tx_energenie [" + getPid() + "]: Exception occurred")
 		print(e)
 
 
 def rx_energenie(address, message):
 	global q_rx_energenie
 
-	#print("rx_energenie: new message from " + str(address) )
+	#print("rx_energenie [" + getPid() + "]: new message from " + str(address) )
 
 	if address[0] == MFRID_ENERGENIE:
 		# Retrieve list of names from the registry, so we can refer to the name of the device
 		for devicename in energenie.registry.names():
-			#print("rx_energenie: checking if message from " + devicename)
+			#print("rx_energenie [" + getPid() + "]: checking if message from " + devicename)
 
 			# Using the name, retrieve the device
 			d = energenie.registry.get(devicename)
@@ -191,13 +194,13 @@ def rx_energenie(address, message):
 			# Check if the message is from the current device of this iteration
 			if address[2] == d.get_device_id():
 				# Yes we found the device, so add to processing queue
-				#print("rx_energenie: Queuing message from " + str(address) + " - " + devicename)
+				#print("rx_energenie [" + getPid() + "]: Queuing message from " + str(address) + " - " + devicename)
 				newQueueEntry = {'DeviceName': devicename, 'DeviceType': address[1]}
 				q_rx_energenie.put(newQueueEntry)
 				# The device was found, so break from the for loop
 				break
 	else:
-		print("rx_energenie: Not an energenie device " + str(address))
+		print("rx_energenie [" + getPid() + "]: Not an energenie device " + str(address))
 
 
 
@@ -206,7 +209,7 @@ def rx_energenie_process():
 
 	while True:
 		try:
-			#print("rx_energenie_process: awaiting item in q_rx_energenie...")
+			#print("rx_energenie_process [" + getPid() + "]: awaiting item in q_rx_energenie...")
 			refreshed_device = q_rx_energenie.get()
 			d = energenie.registry.get( refreshed_device['DeviceName'] )
 
@@ -219,7 +222,7 @@ def rx_energenie_process():
 
 			q_rx_energenie.task_done()
 		except Exception as e:
-			print("rx_energenie_process: exception occurred")
+			print("rx_energenie_process [" + getPid() + "]: exception occurred")
 			print(e)
 
 
@@ -240,33 +243,33 @@ def energenie_tx_mqtt():
 	def energenie_tx_mqtt_on_connect(client, userdata, flags, rc):
 		global energenie_tx_mqtt_client_connected
 		if rc == 0:
-			#print("energenie_tx_mqtt: client connected")
+			#print("energenie_tx_mqtt [" + getPid() + "]: client connected")
 			client.is_connected = True
 			energenie_tx_mqtt_client_connected = True
 
-			print("rx_mqtt: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
+			print("rx_mqtt [" + getPid() + "]: Publishing '" + mqtt_status_msg_connected + "' to '" + mqtt_status_topic + "' and setting last will to '" + mqtt_status_msg_lastwill + "'")
 			# Send a status message so that watchers know what's going on
 			client.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_connected, qos=1, retain=True)
 
 			# Set last will message, so if connection is lost watchers will know
 			client.will_set(topic=mqtt_status_topic_subscribe, payload=mqtt_status_msg_lastwill, qos=1, retain=True)
 		else:
-			print("energenie_tx_mqtt: Bad connection; rc = "+str(rc))
+			print("energenie_tx_mqtt [" + getPid() + "]: Bad connection; rc = "+str(rc))
 	
 	def energenie_tx_mqtt_on_disconnect(client, userdata, rc):
 		global energenie_tx_mqtt_client_connected
-		#print("energenie_tx_mqtt: client disconnected " + str(rc))
+		#print("energenie_tx_mqtt [" + getPid() + "]: client disconnected " + str(rc))
 		client.is_connected = False
 		energenie_tx_mqtt_client_connected = False
 		#client.loop_stop()
 	
 	def energenie_tx_mqtt_on_publish(client, userdata, mid):
-		#print("energenie_tx_mqtt: publish of " + str(mid) + " successful")
+		#print("energenie_tx_mqtt [" + getPid() + "]: publish of " + str(mid) + " successful")
 		pass
 
 	#TODO: Move client instantiation outside of loop, manage connection status with single object
 	while True:
-		print("energenie_tx_mqtt: creating mqtt.client...")
+		print("energenie_tx_mqtt [" + getPid() + "]: creating mqtt.client...")
 		toMqtt = mqtt.Client(client_id=mqtt_client_id, clean_session=mqtt_clean_session)
 		toMqtt.is_connected = False
 		toMqtt.on_connect = energenie_tx_mqtt_on_connect
@@ -274,23 +277,23 @@ def energenie_tx_mqtt():
 		toMqtt.on_publish = energenie_tx_mqtt_on_publish
 
 		if mqtt_username <> "":
-			print("energenie_tx_mqtt: using username and password...")
+			print("energenie_tx_mqtt [" + getPid() + "]: using username and password...")
 			toMqtt.username_pw_set(mqtt_username, mqtt_password)
-		print("energenie_tx_mqtt: connecting to mqtt broker...")
+		print("energenie_tx_mqtt [" + getPid() + "]: connecting to mqtt broker...")
 		toMqtt.connect(mqtt_hostname, mqtt_port, mqtt_keepalive)
-		print("energenie_tx_mqtt: toMqtt.loop_start() thread starting...")
+		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.loop_start() thread starting...")
 		toMqtt.loop_start()
 
 		#while not toMqtt.is_connected:
-		#	print("energenie_tx_mqtt: waiting to ensure connection...")
+		#	print("energenie_tx_mqtt [" + getPid() + "]: waiting to ensure connection...")
 		#	time.sleep(0.5)
 		
 		while not programkiller.kill_now:
 			try:
-				#print("energenie_tx_mqtt: awaiting item in q_tx_mqtt...")
+				#print("energenie_tx_mqtt [" + getPid() + "]: awaiting item in q_tx_mqtt...")
 				item = q_tx_mqtt.get(block=False, timeout=0.2)
 
-				#print("energenie_tx_mqtt: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
+				#print("energenie_tx_mqtt [" + getPid() + "]: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
 				#print(str(item))
 
 				data = item['data']
@@ -303,28 +306,28 @@ def energenie_tx_mqtt():
 						value = ""
 
 					publish_topic = mqtt_publish_topic + "/" + item['DeviceName'] + "/" + metric
-					#print("energenie_tx_mqtt: publishing '" + str( value ) + "' to topic " + publish_topic)
+					#print("energenie_tx_mqtt [" + getPid() + "]: publishing '" + str( value ) + "' to topic " + publish_topic)
 					publish_result = toMqtt.publish(publish_topic, value)
-					#print("energenie_tx_mqtt: publish returned " + str(publish_result[1]))
+					#print("energenie_tx_mqtt [" + getPid() + "]: publish returned " + str(publish_result[1]))
 				q_tx_mqtt.task_done()
 			except Queue.Empty as e:
 				# Empty queue means no payloads pending to be sent, so just loop again
 				pass
 			except Exception as e:
-				print("energenie_tx_mqtt: exception occurred")
+				print("energenie_tx_mqtt [" + getPid() + "]: exception occurred")
 				print(e)
 				if not toMqtt.is_connected:
-					print("energenie_tx_mqtt: mqtt client no longer connected, breaking processing loop")
+					print("energenie_tx_mqtt [" + getPid() + "]: mqtt client no longer connected, breaking processing loop")
 					break
 		
-		print("energenie_tx_mqtt: toMqtt.is_connected == " + str(toMqtt.is_connected))
-		print("energenie_tx_mqtt: toMqtt.loop_stop()")
+		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.is_connected == " + str(toMqtt.is_connected))
+		print("energenie_tx_mqtt [" + getPid() + "]: toMqtt.loop_stop()")
 		toMqtt.loop_stop()
 		if not programkiller.kill_now:
-			print("energenie_tx_mqtt: sleeping for 5 seconds before restarting thread")
+			print("energenie_tx_mqtt [" + getPid() + "]: sleeping for 5 seconds before restarting thread")
 			time.sleep(5)
 		else:
-			print("rx_mqtt: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic + "' then disconnecting...")
+			print("rx_mqtt [" + getPid() + "]: Asked to terminate, sending '" + mqtt_status_msg_disconnected + "' to mqtt '" + mqtt_status_topic + "' then disconnecting...")
 			toMqtt.publish(topic=mqtt_status_topic, payload=mqtt_status_msg_disconnected, qos=1, retain=True)
 			toMqtt.disconnect()
 			break

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -5,7 +5,7 @@ import sys
 import time
 #sys.path.insert(0, '/shared/pyenergenie-master/src')
 import pyenergenie.src.energenie as energenie
-import pyenergenie.src.energenie.Devices as energenie.Devices
+import pyenergenie.src.energenie.Devices as energenieDevices
 import paho.mqtt.client as mqtt
 import Queue
 import threading

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -136,7 +136,7 @@ def rx_mqtt():
 			# manual interface.
 			print("rx_mqtt: Looping forever after this...")
 			while not programkiller.kill_now:
-				fromMqtt.loop(timeout=0.05)
+				fromMqtt.loop(timeout=0.2)
 		except Exception as e:
 			print("rx_mqtt: exception occurred")
 			print(e)
@@ -288,7 +288,7 @@ def energenie_tx_mqtt():
 		while not programkiller.kill_now:
 			try:
 				#print("energenie_tx_mqtt: awaiting item in q_tx_mqtt...")
-				item = q_tx_mqtt.get(block=False, timeout=0.05)
+				item = q_tx_mqtt.get(block=False, timeout=0.2)
 
 				#print("energenie_tx_mqtt: publishing item for " + item['DeviceName'] + " (" + str(item['DeviceType']) + ") found on queue...")
 				#print(str(item))
@@ -372,7 +372,7 @@ def main():
 	while not programkiller.kill_now:
 		energenie.loop()
 		try:
-			msg = q_rx_mqtt.get(block=False,timeout=0.05)
+			msg = q_rx_mqtt.get(block=False,timeout=0.2)
 		except Queue.Empty as e:
 			# Empty queue means do nothing, just keep trying to receive
 			pass

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -197,8 +197,6 @@ def rx_energenie(address, message):
 				#print("rx_energenie: Queuing message from " + str(address) + " - " + devicename)
 				newQueueEntry = {'DeviceId': address[2], 'DeviceName': devicename, 'DeviceType': address[1]}
 				q_rx_energenie.put(newQueueEntry)
-				# The device was found, so break from the for loop
-				break
 		else:
 			print("rx_energenie: Unknown device ID '" + address[2] + "' of type '" + address[1] + "' - maybe a neighbour or a device not yet added")
 	else:

--- a/pyenergenie-mqtt.py
+++ b/pyenergenie-mqtt.py
@@ -348,7 +348,7 @@ def main():
 		device = energenie.registry.get(name)
 
 	while True:
-		energenie.loop()
+		#energenie.loop()
 		time.sleep(0.25)
 
 


### PR DESCRIPTION
This branch has been me refactoring a little, but mostly working on bringing the ability to send commands to an MQTT queue, and have them actioned on the Energenie device. I've also cleaned up a bunch of stuff, and reduced some of the logging verbosity. There are further improvements I could probably make, but if I'm honest I think if I need them I'll probably move to the more actively maintenance nodeJS module in Node Red by @Achronite.

About time these changes went live, as I've been running them for some time on my own device.

The only reservation I have, is that the programme seems to use 100% of a core at all times. Its in the main thread, and I've done some testing and I *think* its just the pyenergenie library with how it does radio receives. I can't recall if it used to do it and I think I've made big enough changes that I couldn't easily roll back to master to check; at least not without breaking the things that depend on my instance of this code.